### PR TITLE
一些优化和改进

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -9,71 +9,48 @@ import (
 
 const (
 	UserAgent      = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"
-	BiliUrl        = "www.bilibili.com"
 	BiliLiveApiUrl = "api.live.bilibili.com"
+	MainWsUrl      = "broadcastlv.chat.bilibili.com"
 )
 
 var cookies = ""
 
-func getReq(data url.Values, getUrl string, cookies string) ([]byte, string, error) {
+func getReq(data url.Values, getUrl string) ([]byte, error) {
 	u, err := url.ParseRequestURI(getUrl)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	u.RawQuery = data.Encode()
 	client := http.Client{}
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	req.Header = http.Header{
 		"User-Agent": {UserAgent},
-		"cookie":     {cookies},
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	defer func(Body io.ReadCloser) {
 		_ = Body.Close()
 	}(resp.Body)
 	if resp.StatusCode != 200 {
-		return nil, "", RespCodeNotError
-	}
-	if resp.Header.Get("Set-Cookie") != "" {
-		cookies = ""
-		for _, v := range resp.Header["Set-Cookie"] {
-			cookies += v + ";"
-		}
-	} else {
-		cookies = ""
+		return nil, RespCodeNotError
 	}
 	s, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
-	return s, cookies, nil
-}
-
-func getCookies() string {
-	getUrl := url.URL{Scheme: "https", Host: BiliUrl, Path: "/"}
-	data := url.Values{}
-	data.Set("spm_id_from", "333.999.0.0")
-	_, cookies, err := getReq(data, getUrl.String(), "")
-	if err != nil {
-		return ""
-	}
-	return cookies
+	return s, nil
 }
 
 func GetLiveRoomAuth(roomId int) (ApiLiveAuth, error) {
-	if cookies == "" {
-		cookies = getCookies()
-	}
 	getUrl := url.URL{Scheme: "https", Host: BiliLiveApiUrl, Path: "/xlive/web-room/v1/index/getDanmuInfo"}
 	data := url.Values{}
 	data.Set("id", strconv.Itoa(roomId))
-	s, _, err := getReq(data, getUrl.String(), cookies)
+	s, err := getReq(data, getUrl.String())
 	if err != nil {
 		return ApiLiveAuth{}, err
 	}

--- a/client/api.go
+++ b/client/api.go
@@ -61,3 +61,19 @@ func GetLiveRoomAuth(roomId int) (ApiLiveAuth, error) {
 	}
 	return jBA, nil
 }
+
+func GetRealRoomId(roomId int) (int, error) {
+	getUrl := url.URL{Scheme: "https", Host: BiliLiveApiUrl, Path: "/xlive/web-room/v1/index/getRoomPlayInfo"}
+	data := url.Values{}
+	data.Set("room_id", strconv.Itoa(roomId))
+	s, err := getReq(data, getUrl.String())
+	if err != nil {
+		return 0, err
+	}
+	var jBA ApiLiveRoomId
+	err = JsonCoder.Unmarshal(s, &jBA)
+	if err != nil {
+		return 0, err
+	}
+	return jBA.Data.RoomID, nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -170,4 +170,5 @@ func (c *Client) BiliChat(CmdChan chan map[string]interface{}) {
 	go c.revHandler(handler)
 	go c.receiveWsMsg()
 	go c.heartBeat()
+	log.Debug("start blive success", c.RoomId)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -102,28 +102,33 @@ func (c *Client) revHandler(handler MsgHandler) {
 
 func (c *Client) sendConnect() error {
 	wsAuthMsg := WsAuthMessage{Body: WsAuthBody{UID: 0, Roomid: c.RoomId, Protover: 3, Platform: "web", Type: 2}}
-	apiLiveAuth, err := GetLiveRoomAuth(c.RoomId)
+	u := url.URL{Scheme: "wss", Host: MainWsUrl, Path: "/sub"}
+	log.Debug("connect to blive websocket: ", u.String())
+	err := c.biliChatConnect(u.String())
 	if err != nil {
-		return err
-	} else if apiLiveAuth.Code != 0 {
-		log.Warnf("get live room info error: %v", apiLiveAuth.Message)
-		return RespCodeNotError
-	}
-	wsAuthMsg.Body.Key = apiLiveAuth.Data.Token
-	for nowSum, i := range apiLiveAuth.Data.HostList {
-		u := url.URL{Scheme: "wss", Host: i.Host + ":" + strconv.Itoa(i.WssPort), Path: "/sub"}
-		log.Debug("connect to blive websocket: ", u.String())
-		err = c.biliChatConnect(u.String())
+		apiLiveAuth, err := GetLiveRoomAuth(c.RoomId)
 		if err != nil {
-			log.Warnf("connect to blive websocket error for %d time: %v\n", nowSum, err)
-			if nowSum == 2 {
-				return err
-			}
-		} else {
-			log.Debug("connect to blive websocket success")
-			break
+			return err
+		} else if apiLiveAuth.Code != 0 {
+			log.Warnf("get live room info error: %v", apiLiveAuth.Message)
+			return RespCodeNotError
 		}
-		time.Sleep(1 * time.Second)
+		wsAuthMsg.Body.Key = apiLiveAuth.Data.Token
+		for nowSum, i := range apiLiveAuth.Data.HostList {
+			u := url.URL{Scheme: "wss", Host: i.Host + ":" + strconv.Itoa(i.WssPort), Path: "/sub"}
+			log.Debug("connect to blive websocket: ", u.String())
+			err = c.biliChatConnect(u.String())
+			if err != nil {
+				log.Warnf("connect to blive websocket error for %d time: %v\n", nowSum, err)
+				if nowSum == 2 {
+					return err
+				}
+			} else {
+				log.Debug("connect to blive websocket success")
+				break
+			}
+			time.Sleep(1 * time.Second)
+		}
 	}
 	err = c.sendAuthMsg(wsAuthMsg)
 	if err != nil {

--- a/client/template.go
+++ b/client/template.go
@@ -40,6 +40,31 @@ type ApiLiveAuth struct {
 	} `json:"data"`
 }
 
+type ApiLiveRoomId struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	TTL     int    `json:"ttl"`
+	Data    struct {
+		RoomID          int           `json:"room_id"`
+		ShortID         int           `json:"short_id"`
+		UID             int           `json:"uid"`
+		NeedP2P         int           `json:"need_p2p"`
+		IsHidden        bool          `json:"is_hidden"`
+		IsLocked        bool          `json:"is_locked"`
+		IsPortrait      bool          `json:"is_portrait"`
+		LiveStatus      int           `json:"live_status"`
+		HiddenTill      int           `json:"hidden_till"`
+		LockTill        int           `json:"lock_till"`
+		Encrypted       bool          `json:"encrypted"`
+		PwdVerified     bool          `json:"pwd_verified"`
+		LiveTime        int           `json:"live_time"`
+		RoomShield      int           `json:"room_shield"`
+		IsSp            int           `json:"is_sp"`
+		SpecialType     int           `json:"special_type"`
+		PlayURL         interface{}   `json:"play_url"`
+		AllSpecialTypes []interface{} `json:"all_special_types"`
+	} `json:"data"`
+}
 type WsHeader struct {
 	PackageLen uint32
 	HeaderLen  uint16

--- a/main.go
+++ b/main.go
@@ -48,6 +48,15 @@ func (h *Handler) AddRoom(roomId int) {
 		return
 	}
 	room := LiveRoom{}
+	if roomId <= 10000 {
+		RealroomId, err := client.GetRealRoomId(roomId)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		log.Info(roomId, " is short roomid, the real roomid is: ", RealroomId)
+		roomId = RealroomId
+	}
 	room.RoomId = roomId
 	room.Client.RoomId = room.RoomId
 	room.Client.BiliChat(h.Handler.CmdChan)


### PR DESCRIPTION
1.[删除没必要的cookie获取](https://github.com/XiaoMiku01/go-bili-chat/commit/a15e6066b3ad01678a7c0f4a2dd75c8354cbd01e)  
不需要 `cookie` 也可以获取接口消息。原来的写法用全局变量保存在并发情况下有概率会多次请求B站主站，可能会被拦截，测试后发现 `cookie` 可以不需要。
2.[弹幕池默认不走cdn，默认可以发送空字符串token](https://github.com/XiaoMiku01/go-bili-chat/commit/3e4bd664754de59e68e02aac7ec2726050c16d24)  
弹幕池的ws链接的cdn并不稳定。而且过期，可以直接连接主弹幕池 `broadcastlv.chat.bilibili.com` ,而且不需要验证 `token` 也可以获取ws数据包，减少了请求次数。  
3.[适配房间号为短号的情况](https://github.com/XiaoMiku01/go-bili-chat/commit/0e37010bd5d388953698a311797679647feb0e1a)  
有些主播的房间号为短号，必须获取真是房间id才能连接到弹幕池，这里做了适配，房间号短于五位数的都会默认去获取真实房间号。

最后希望作者添加断线重连机制，以适应网络环境不好的情况。感谢！